### PR TITLE
Add lca & update arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ output_path/
 │   ├── sample1_denoise_report.txt
 │   └── ...
 ├── blast/                   # Taxonomic assignments
-│   ├── sample1.csv          # Sequentially enriched: BLAST → lineage → LCA → haplotype
+│   ├── sample1.csv          # Sequentially enriched: BLAST -> lineage -> LCA -> haplotype
 │   └── ...
 └── stages.log               # Processing log
 ```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ Core processing pipeline with the following stages:
 - **FASTQ to FASTA**: Format conversion
 - **Dereplicate**: Remove duplicate sequences
 - **Denoise**: Error correction
-- **Assign Taxa**: Taxonomic classification
+- **BLAST**: Taxonomic classification against a reference database
+- **Add Lineage**: Annotate BLAST hits with full taxonomic lineage
+- **LCA**: Resolve multiple hits per query to a consensus taxonomy using Lowest Common Ancestor
+- **Add Haplotype**: Enrich results with haplotype sequence and abundance data
 
 ### 2. Data Management (`data`)
 
@@ -124,7 +127,7 @@ output_path/
 │   ├── sample1_denoise_report.txt
 │   └── ...
 ├── blast/                   # Taxonomic assignments
-│   ├── sample1.csv          # Enhanced with lineage (addlineage) and haplotype (addhap) info
+│   ├── sample1.csv          # Sequentially enriched: BLAST → lineage → LCA → haplotype
 │   └── ...
 └── stages.log               # Processing log
 ```
@@ -149,9 +152,10 @@ The pipeline automatically:
 4. Converts FASTQ to FASTA format
 5. Removes duplicate sequences
 6. Performs error correction (denoising)
-7. Assigns taxonomy using BLAST
-8. Adds lineage information
-9. Enriches with haplotype data
+7. Assigns taxonomy using BLAST (top 20 hits per query by default)
+8. Adds full taxonomic lineage to each BLAST hit
+9. Resolves multiple hits per query to a consensus taxonomy via LCA
+10. Enriches with haplotype sequence and abundance data
 
 #### Run custom settings
 
@@ -165,9 +169,13 @@ custom_settings = {
     "min_read_len": 154,
     "max_read_len": 189,
     
-    # Database paths
+    # Blast settings
     "blast_db": "/path/to/custom/blast/db",
     "lineage_db": "/path/to/custom/lineage/db",
+    "maxhitnum": 100,
+    
+    # LCA settings
+    "tol_pct": 1.0,
     
     # Performance settings
     "verbose": True,
@@ -188,7 +196,7 @@ You can start the pipeline at any stage by specifying `enabled_stages`:
 ```python
 # Start from merge stage (skip decompress)
 settings = {
-    "enabled_stages": ["merge", "cutprimer", "fqtofa", "dereplicate", "denoise", "blast", "addlineage", "addhap"],
+    "enabled_stages": ["merge", "cutprimer", "fqtofa", "dereplicate", "denoise", "blast", "addlineage", "lca", "addhap"],
 }
 pipeline = BioPipeline(
     input_path="/path/to/files_with_R1_R2_fastq",  # decompressed FASTQ files
@@ -198,7 +206,7 @@ pipeline = BioPipeline(
 
 # Start from fqtofa stage (skip decompress and merge)
 settings = {
-    "enabled_stages": ["fqtofa", "dereplicate", "denoise", "blast", "addlineage", "addhap"],
+    "enabled_stages": ["fqtofa", "dereplicate", "denoise", "blast", "addlineage", "lca", "addhap"],
 }
 pipeline = BioPipeline(
     input_path="/path/to/files_with_merged_trimmed_fastq",

--- a/src/ednabp/bp/run_bp.py
+++ b/src/ednabp/bp/run_bp.py
@@ -53,6 +53,10 @@ class BioPipeline:
             - error_rate (float): The maximum rate of error could be tolerated. The actual error rate is computed as the number of errors in the match divided by the length of the matching part of the primer. Default: 0.15.
             - min_read_len (int): Discard processed reads that are shorter than this parameter. Default: 204.
             - max_read_len (int): Discard processed reads that are longer than this parameter. Default: 254.
+            - revcomp (bool): If True, also search the reverse complement of each read for primer matches and output reads in the orientation where the primer was found. Default: True.
+
+          Dereplicate Settings:
+            - strand (bool): If True, treat a sequence and its reverse complement as duplicates during dereplication (-strand both). If False, only the forward strand is considered (-strand plus). Default: True.
 
           Denoise Settings:
             - minsize (int): Discard sequences with abundance that are smaller than this parameter. Default: 8.
@@ -148,6 +152,9 @@ class BioPipeline:
         self.cutprimer_settings = {
             k: settings.get(k, v) for k, v in SETTINGS["cutprimer"].items()
         }
+        self.dereplicate_settings = {
+            k: settings.get(k, v) for k, v in SETTINGS["dereplicate"].items()
+        }
         self.denoise_settings = {
             k: settings.get(k, v) for k, v in SETTINGS["denoise"].items()
         }
@@ -242,6 +249,7 @@ class BioPipeline:
             if stage in [
                 "merge",
                 "cutprimer",
+                "dereplicate",
                 "denoise",
                 "blast",
                 "addlineage",

--- a/src/ednabp/bp/run_bp.py
+++ b/src/ednabp/bp/run_bp.py
@@ -41,7 +41,7 @@ class BioPipeline:
          ["decompress", "merge", "cutprimer", "fqtofa", "dereplicate", "denoise", "blast", "addlineage", "addhap"] (all stages will be run).
         :param settings: Additional optional arguments to configure pipeline stages and runtime behavior. These include:
           Input File Suffix:
-            - raw_suffix (str): File suffix for raw input sequences. Default: "AUTO" (auto-detected based on starting stage).
+            - raw_suffix (str): File suffix for raw input sequences. Default: auto-detected from the starting stage.
 
           Merge Settings:
             - maxdiff (int): Maximum number of mismatches in the alignment. Default: 5.
@@ -75,6 +75,9 @@ class BioPipeline:
             - tol_pct (float): Percentage of the top bitscore used as the inclusion threshold before LCA. Hits with bitscore >= top * (1 - tol_pct / 100) are included in the consensus. Default: 1.0.
             - score_column (str): Column used for score-based filtering. Default: 'bitscore'.
             - qseqid_column (str): Column used to group hits by query sequence. Default: 'qseqid'.
+
+          Add Haplotype Settings:
+            - denoise_dir (str): Path to the directory containing denoised FASTA and report files used by addhap. Default: the pipeline's own denoise output directory.
 
           External Program Setting:
             - usearch_prog (str): Command to execute USEARCH for merge, dereplicate, and denoise stages. Default: "usearch".
@@ -157,7 +160,9 @@ class BioPipeline:
         self.lca_settings = {
             k: settings.get(k, v) for k, v in SETTINGS["lca"].items()
         }
-        self.addhap_settings = {}
+        self.addhap_settings = {
+            k: settings.get(k, v) for k, v in SETTINGS["addhap"].items()
+        }
         self.prog_settings = {
             k: settings.get(f"{k}_prog", v)
             for k, v in SETTINGS["prog"].items()
@@ -180,7 +185,7 @@ class BioPipeline:
 
     def determine_raw_suffix(self):
         raw_suffix = self.stage_suffix["raw"]
-        if raw_suffix != SETTINGS["suffix"]["raw"]:
+        if raw_suffix is not None:
             self.config.logger.info(
                 f"Using user-specified raw_suffix: {raw_suffix}"
             )
@@ -229,7 +234,10 @@ class BioPipeline:
                 stage_args["blast_prog"] = self.prog_settings["blast"]
 
             if stage == "addhap":
-                stage_args["denoise_dir"] = self.stage_dir["denoise"]
+                stage_args["denoise_dir"] = (
+                    self.addhap_settings["denoise_dir"]
+                    or self.stage_dir["denoise"]
+                )
 
             if stage in [
                 "merge",

--- a/src/ednabp/bp/run_bp.py
+++ b/src/ednabp/bp/run_bp.py
@@ -12,6 +12,7 @@ from .step_exec import (
     denoise,
     dereplicate,
     fqtofa,
+    lca,
     merge,
 )
 
@@ -24,6 +25,7 @@ STAGE_INPUT_SUFFIX = {
     "denoise": ".fasta",
     "blast": ".fasta",
     "addlineage": ".csv",
+    "lca": ".csv",
     "addhap": ".csv",
 }
 
@@ -60,6 +62,7 @@ class BioPipeline:
             - evalue (float): Expectation value (E) threshold for saving hits. Default: 0.00001.
             - qcov_hsp_perc (int): The %threshold of the query sequence that has to form an alignment against the reference to be retained. Default: 90.
             - perc_identity (int): Minimum percentage identity required for taxonomic assignment. Default: 90.
+            - maxhitnum (int): Maximum number of hits to keep per query sequence. Default: 20.
             - specifiers (str): Output format specifiers for BLAST results. Default:
               "qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore".
             - blast_db (str): Path to the taxonomic database. Default: 'nt'.
@@ -68,9 +71,14 @@ class BioPipeline:
             - lineage_db (str): Path to the taxonomic lineage file. Default: 'nucleotide'.
             - entrez_email (str): The email used by NCBI to contact you in case of excessive usage or issues. Default: None
 
+          LCA Settings:
+            - tol_pct (float): Percentage of the top bitscore used as the inclusion threshold before LCA. Hits with bitscore >= top * (1 - tol_pct / 100) are included in the consensus. Default: 1.0.
+            - score_column (str): Column used for score-based filtering. Default: 'bitscore'.
+            - qseqid_column (str): Column used to group hits by query sequence. Default: 'qseqid'.
+
           External Program Setting:
             - usearch_prog (str): Command to execute USEARCH for merge, dereplicate, and denoise stages. Default: "usearch".
-            - cutadapt_prog (str): Command to execute Cutadapt for primer trimming stage. Default: "cutadapt".
+            - cutadapt_prog (str): Command to execute Cutadapt for cutprimer stage. Default: "cutadapt".
             - blast_prog (str): Command to execute BLAST for blast stage. Default: "blastn".
 
           Configuration Settings:
@@ -116,6 +124,7 @@ class BioPipeline:
             "denoise": denoise.DenoiseStage,
             "blast": blast.BlastStage,
             "addlineage": addlineage.AddLineageStage,
+            "lca": lca.LcaStage,
             "addhap": addhap.AddHapStage,
         }
 
@@ -144,6 +153,9 @@ class BioPipeline:
         }
         self.addlineage_settings = {
             k: settings.get(k, v) for k, v in SETTINGS["addlineage"].items()
+        }
+        self.lca_settings = {
+            k: settings.get(k, v) for k, v in SETTINGS["lca"].items()
         }
         self.addhap_settings = {}
         self.prog_settings = {
@@ -225,6 +237,7 @@ class BioPipeline:
                 "denoise",
                 "blast",
                 "addlineage",
+                "lca",
             ]:
                 stage_args.update(eval(f"self.{stage}_settings"))
 

--- a/src/ednabp/bp/step_exec/cutprimer.py
+++ b/src/ednabp/bp/step_exec/cutprimer.py
@@ -19,6 +19,7 @@ class CutPrimerStage(stage_builder.StageBuilder):
         error_rate=0.15,
         min_read_len=163,
         max_read_len=185,
+        revcomp: bool = True,
     ):
         super().__init__(
             heading=heading, config=config, in_dir=in_dir, out_dir=out_dir
@@ -28,17 +29,19 @@ class CutPrimerStage(stage_builder.StageBuilder):
         self.out_suffix = out_suffix
         self.report_suffix = SETTINGS["suffix"]["report"]
         self.parse_params(
-            rm_p_5, rm_p_3, min_read_len, max_read_len, error_rate
+            rm_p_5, rm_p_3, min_read_len, max_read_len, error_rate, revcomp
         )
 
     def parse_params(
-        self, rm_p_5, rm_p_3, min_read_len, max_read_len, error_rate
+        self, rm_p_5, rm_p_3, min_read_len, max_read_len, error_rate, revcomp
     ):
         self.params = (
             f"-g {rm_p_5};max_error_rate={error_rate}...{rm_p_3};max_error_rate={error_rate}"
             f" --minimum-length {min_read_len}"
             f" --maximum-length {max_read_len}"
         )
+        if revcomp:
+            self.params += " --revcomp"
 
     def setup(self, prefix):
         self.infile = os.path.join(self.in_dir, f"{prefix}{self.in_suffix}")

--- a/src/ednabp/bp/step_exec/dereplicate.py
+++ b/src/ednabp/bp/step_exec/dereplicate.py
@@ -17,6 +17,7 @@ class DereplicateStage(stage_builder.StageBuilder):
         annot_size: bool = True,
         seq_label: str = "Uniq",
         write_report: bool = True,
+        strand: bool = True,
     ):
         super().__init__(
             heading=heading, config=config, in_dir=in_dir, out_dir=out_dir
@@ -26,13 +27,15 @@ class DereplicateStage(stage_builder.StageBuilder):
         self.out_suffix = out_suffix
         self.report_suffix = SETTINGS["suffix"]["report"]
         self.write_report = write_report
-        self.parse_params(annot_size, seq_label)
+        self.parse_params(annot_size, seq_label, strand)
 
-    def parse_params(self, annot_size, seq_label):
+    def parse_params(self, annot_size, seq_label, strand):
         sizeout = "-sizeout" if annot_size else ""
         self.params = f"{sizeout}"
         if seq_label:
             self.params += f" -relabel {seq_label}"
+        if strand:
+            self.params += " -strand both"
 
     def setup(self, prefix):
         self.infile = os.path.join(self.in_dir, f"{prefix}{self.in_suffix}")

--- a/src/ednabp/bp/step_exec/lca.py
+++ b/src/ednabp/bp/step_exec/lca.py
@@ -1,0 +1,126 @@
+import os
+
+import pandas as pd
+
+from ..step_build import stage_builder
+from .addlineage import RANKS
+
+
+def normalize_species_names(name):
+    if pd.isna(name) or name == "":
+        return []
+    if "_x_" in name:
+        return name.split("_x_")
+    parts = name.split("_")
+    if len(parts) >= 3:
+        return [name, "_".join(parts[:2])]
+    if "_sp." in name:
+        return [name, name.split("_")[0] + "_sp."]
+    return [name]
+
+
+def filter_by_score(group, score_column, tol_pct):
+    if group.empty:
+        return group
+    highest = group[score_column].max()
+    return group[group[score_column] >= highest * (1 - tol_pct / 100)]
+
+
+def lca_of_lineages(lineages):
+    result = [""] * len(RANKS)
+    lca_rank = "NA"
+    last_i = len(RANKS) - 1
+
+    for i, col in enumerate(RANKS):
+        per_hit = []
+        any_missing = False
+        for lineage in lineages:
+            candidates = set(normalize_species_names(lineage[i]))
+            if candidates:
+                per_hit.append(candidates)
+            else:
+                any_missing = True
+
+        if any_missing:
+            if i == last_i:
+                break
+            continue
+
+        if not per_hit:
+            break
+
+        common = per_hit[0].copy()
+        for s in per_hit[1:]:
+            common &= s
+
+        if common:
+            result[i] = max(common, key=len)
+            lca_rank = col
+        else:
+            break
+
+    return result, lca_rank
+
+
+class LcaStage(stage_builder.StageBuilder):
+    def __init__(
+        self,
+        config,
+        heading=os.path.basename(__file__),
+        in_dir="",
+        out_dir="",
+        in_suffix=".csv",
+        out_suffix=".csv",
+        tol_pct: float = 1.0,
+        score_column: str = "bitscore",
+        qseqid_column: str = "qseqid",
+    ):
+        super().__init__(
+            heading=heading, config=config, in_dir=in_dir, out_dir=out_dir
+        )
+        self.in_suffix = in_suffix
+        self.out_suffix = out_suffix
+        self.tol_pct = tol_pct
+        self.score_column = score_column
+        self.qseqid_column = qseqid_column
+
+    def setup(self, prefix):
+        self.infile = os.path.join(self.in_dir, f"{prefix}{self.in_suffix}")
+        self.outfile = os.path.join(self.out_dir, f"{prefix}{self.out_suffix}")
+        self.check_infile()
+        if not self.config.dry:
+            super().add_stage_function("Run LCA", self.run_lca)
+
+    def run_lca(self):
+        try:
+            df = pd.read_csv(self.infile)
+            non_tax_cols = [c for c in df.columns if c not in RANKS]
+            results = []
+
+            for seq_name, group in df.groupby(self.qseqid_column, sort=False):
+                filtered = filter_by_score(
+                    group, self.score_column, self.tol_pct
+                )
+                if filtered.empty:
+                    continue
+
+                lineages = filtered[RANKS].values.tolist()
+                lca_lineage, lca_rank = lca_of_lineages(lineages)
+
+                best_row = filtered.loc[filtered[self.score_column].idxmax()]
+                row = {col: best_row[col] for col in non_tax_cols}
+                for i, col in enumerate(RANKS):
+                    row[col] = lca_lineage[i]
+                row["lca_rank"] = lca_rank
+                row["num_assignments"] = len(filtered)
+                results.append(row)
+
+            pd.DataFrame(results).to_csv(self.outfile, index=False)
+            return True
+        except Exception as e:
+            self.config.logger.error(f"LCA failed: {e}")
+            return False
+
+    def run(self):
+        super().run()
+        return all(self.output)

--- a/src/ednabp/cli/pipeline.py
+++ b/src/ednabp/cli/pipeline.py
@@ -103,6 +103,24 @@ def main():
                     "help": "Maximum length of processed reads (default: %(default)s).",
                 },
             },
+            {
+                "args": ["--revcomp"],
+                "kwargs": {
+                    "action": argparse.BooleanOptionalAction,
+                    "default": SETTINGS["cutprimer"]["revcomp"],
+                    "help": "Also search the reverse complement of each read for primer matches and output reads in the matched orientation (default: %(default)s).",
+                },
+            },
+        ],
+        "Dereplicate Settings": [
+            {
+                "args": ["--strand"],
+                "kwargs": {
+                    "action": argparse.BooleanOptionalAction,
+                    "default": SETTINGS["dereplicate"]["strand"],
+                    "help": "Treat a sequence and its reverse complement as duplicates during dereplication (default: %(default)s).",
+                },
+            },
         ],
         "Denoising Settings": [
             {
@@ -256,7 +274,7 @@ def main():
             {
                 "args": ["--verbose"],
                 "kwargs": {
-                    "action": "store_true",
+                    "action": argparse.BooleanOptionalAction,
                     "default": SETTINGS["config_basic"]["verbose"],
                     "help": "Enable detailed logging output (default: %(default)s).",
                 },

--- a/src/ednabp/cli/pipeline.py
+++ b/src/ednabp/cli/pipeline.py
@@ -148,6 +148,14 @@ def main():
                 },
             },
             {
+                "args": ["--maxhitnum"],
+                "kwargs": {
+                    "type": int,
+                    "default": SETTINGS["blast"]["maxhitnum"],
+                    "help": "Maximum number of hits to keep per query sequence (default: %(default)s).",
+                },
+            },
+            {
                 "args": ["--specifiers"],
                 "kwargs": {
                     "type": str,
@@ -182,6 +190,32 @@ def main():
                 },
             },
         ],
+        "LCA Settings": [
+            {
+                "args": ["--tol-pct"],
+                "kwargs": {
+                    "type": float,
+                    "default": SETTINGS["lca"]["tol_pct"],
+                    "help": "Percentage of the top bitscore used as the inclusion threshold before LCA. Hits with bitscore >= top * (1 - tol_pct / 100) are included in the consensus (default: %(default)s).",
+                },
+            },
+            {
+                "args": ["--score-column"],
+                "kwargs": {
+                    "type": str,
+                    "default": SETTINGS["lca"]["score_column"],
+                    "help": "Column used for score-based hit filtering (default: %(default)s).",
+                },
+            },
+            {
+                "args": ["--qseqid-column"],
+                "kwargs": {
+                    "type": str,
+                    "default": SETTINGS["lca"]["qseqid_column"],
+                    "help": "Column used to group hits by query sequence (default: %(default)s).",
+                },
+            },
+        ],
         "External Program Settings": [
             {
                 "args": ["--usearch-prog"],
@@ -196,7 +230,7 @@ def main():
                 "kwargs": {
                     "type": str,
                     "default": SETTINGS["prog"]["cutadapt"],
-                    "help": "Command to execute Cutadapt for primer trimming stage (default: %(default)s).",
+                    "help": "Command to execute Cutadapt for cutprimer stage (default: %(default)s).",
                 },
             },
             {

--- a/src/ednabp/cli/pipeline.py
+++ b/src/ednabp/cli/pipeline.py
@@ -40,7 +40,7 @@ def main():
                 "kwargs": {
                     "type": str,
                     "default": SETTINGS["suffix"]["raw"],
-                    "help": "File suffix for raw input files. Use 'AUTO' for auto-detection based on starting stage (default: %(default)s).",
+                    "help": "File suffix for raw input files (default: auto-detected from starting stage).",
                 },
             },
         ],
@@ -213,6 +213,16 @@ def main():
                     "type": str,
                     "default": SETTINGS["lca"]["qseqid_column"],
                     "help": "Column used to group hits by query sequence (default: %(default)s).",
+                },
+            },
+        ],
+        "Add Haplotype Settings": [
+            {
+                "args": ["--denoise-dir"],
+                "kwargs": {
+                    "type": str,
+                    "default": SETTINGS["addhap"]["denoise_dir"],
+                    "help": "Path to the denoised sequences directory used by addhap (default: pipeline denoise output directory).",
                 },
             },
         ],

--- a/src/ednabp/common/default_settings.py
+++ b/src/ednabp/common/default_settings.py
@@ -50,6 +50,10 @@ SETTINGS = {
         "error_rate": 0.15,
         "min_read_len": 163,
         "max_read_len": 185,
+        "revcomp": True,
+    },
+    "dereplicate": {
+        "strand": True,
     },
     "denoise": {
         "minsize": 8,

--- a/src/ednabp/common/default_settings.py
+++ b/src/ednabp/common/default_settings.py
@@ -10,6 +10,7 @@ SETTINGS = {
         "denoise",
         "blast",
         "addlineage",
+        "lca",
         "addhap",
     ],
     "dir_name": {
@@ -21,6 +22,7 @@ SETTINGS = {
         "denoise": "denoise",
         "blast": "blast",
         "addlineage": "blast",
+        "lca": "blast",
         "addhap": "blast",
     },
     "suffix": {
@@ -33,6 +35,7 @@ SETTINGS = {
         "denoise": ".fasta",
         "blast": ".csv",
         "addlineage": ".csv",
+        "lca": ".csv",
         "addhap": ".csv",
         "report": "_report.txt",
         "denoise_report": "_denoise_report.txt",
@@ -56,12 +59,18 @@ SETTINGS = {
         "evalue": 0.00001,
         "qcov_hsp_perc": 90,
         "perc_identity": 90,
+        "maxhitnum": 20,
         "specifiers": "qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore",
         "blast_db": "nt",
     },
     "addlineage": {
         "lineage_db": "nucleotide",
         "entrez_email": None,
+    },
+    "lca": {
+        "tol_pct": 1.0,
+        "score_column": "bitscore",
+        "qseqid_column": "qseqid",
     },
     "prog": {
         "usearch": "usearch",

--- a/src/ednabp/common/default_settings.py
+++ b/src/ednabp/common/default_settings.py
@@ -26,7 +26,7 @@ SETTINGS = {
         "addhap": "blast",
     },
     "suffix": {
-        "raw": "AUTO",
+        "raw": None,
         "decompress": "_R1.fastq",
         "merge": ".fastq",
         "cutprimer": ".fastq",
@@ -71,6 +71,9 @@ SETTINGS = {
         "tol_pct": 1.0,
         "score_column": "bitscore",
         "qseqid_column": "qseqid",
+    },
+    "addhap": {
+        "denoise_dir": None,
     },
     "prog": {
         "usearch": "usearch",

--- a/tests/test_bio_pipeline.py
+++ b/tests/test_bio_pipeline.py
@@ -8,6 +8,12 @@ from ednabp.bp.run_bp import BioPipeline
 from ednabp.common.config import Config
 
 
+def mock_add_config(self):
+    self.config = Mock()
+    self.config.logger = Mock()
+    self.config.logger.handlers = []
+
+
 class TestBioPipeline:
     @pytest.fixture
     def sample_fastq_files(self, tmp_dirs):
@@ -130,10 +136,6 @@ class TestBioPipeline:
         input_file = os.path.join(in_dir, "test.custom_suffix")
         with open(input_file, "w") as f:
             f.write("test")
-
-        def mock_add_config(self):
-            self.config = Mock()
-            self.config.logger = Mock()
 
         with (
             patch.object(BioPipeline, "setup_stages"),
@@ -272,10 +274,6 @@ class TestBioPipeline:
         with open(input_file, "w") as f:
             f.write("test")
 
-        def mock_add_config(self):
-            self.config = Mock()
-            self.config.logger = Mock()
-
         with (
             patch.object(BioPipeline, "run_stages_files"),
             patch.object(BioPipeline, "close_file_handler"),
@@ -302,11 +300,6 @@ class TestBioPipeline:
         with open(input_file, "w") as f:
             f.write("test")
 
-        def mock_add_config(self):
-            self.config = Mock()
-            self.config.logger = Mock()
-            self.config.logger.handlers = []
-
         with (
             patch.object(BioPipeline, "run_stages_files"),
             patch.object(BioPipeline, "add_config", mock_add_config),
@@ -330,10 +323,6 @@ class TestBioPipeline:
 
         def mock_determine_suffix(self):
             self.stage_suffix["raw"] = ".fasta"
-
-        def mock_add_config(self):
-            self.config = Mock()
-            self.config.logger = Mock()
 
         with (
             patch.object(BioPipeline, "run_stages_files"),
@@ -426,11 +415,6 @@ class TestBioPipeline:
     def test_run_stages_files(self, sample_fastq_files, tmp_dirs):
         in_dir, out_dir = tmp_dirs
 
-        def mock_add_config(self):
-            self.config = Mock()
-            self.config.logger = Mock()
-            self.config.logger.handlers = []
-
         with (
             patch.object(BioPipeline, "add_config", mock_add_config),
             patch.object(BioPipeline, "setup_stages"),
@@ -456,11 +440,6 @@ class TestBioPipeline:
         input_file = os.path.join(in_dir, "single_sample_R1.fastq.gz")
         with open(input_file, "w") as f:
             f.write("test")
-
-        def mock_add_config(self):
-            self.config = Mock()
-            self.config.logger = Mock()
-            self.config.logger.handlers = []
 
         with (
             patch.object(BioPipeline, "add_config", mock_add_config),
@@ -500,10 +479,6 @@ class TestBioPipeline:
             "cutadapt_prog": "custom_cutadapt",
             "blast_prog": "custom_blastn",
         }
-
-        def mock_add_config(self):
-            self.config = Mock()
-            self.config.logger = Mock()
 
         with (
             patch.object(BioPipeline, "run_stages_files"),
@@ -552,10 +527,6 @@ class TestBioPipeline:
         with open(input_file, "w") as f:
             f.write("test")
 
-        def mock_add_config(self):
-            self.config = Mock()
-            self.config.logger = Mock()
-
         with (
             patch.object(BioPipeline, "run_stages_files"),
             patch.object(BioPipeline, "close_file_handler"),
@@ -583,10 +554,6 @@ class TestBioPipeline:
         input_file = os.path.join(in_dir, "test_R1.fastq.gz")
         with open(input_file, "w") as f:
             f.write("test")
-
-        def mock_add_config(self):
-            self.config = Mock()
-            self.config.logger = Mock()
 
         with (
             patch.object(BioPipeline, "run_stages_files"),

--- a/tests/test_cutprimer_stage.py
+++ b/tests/test_cutprimer_stage.py
@@ -75,7 +75,7 @@ class TestCutPrimerStage:
         expected_command = (
             f"cutadapt {expected_infile}"
             f" -g GTCGGTAAAACTCGTGCCAGC;max_error_rate=0.15...CAAACTGGGATTAGATACCCCACTATG;max_error_rate=0.15"
-            f" --minimum-length 163 --maximum-length 185 -j 4"
+            f" --minimum-length 163 --maximum-length 185 --revcomp -j 4"
             f" --untrimmed-output {expected_untrimmed_file}"
             f" --too-short-output {expected_tooshort_file}"
             f" --too-long-output {expected_toolong_file}"

--- a/tests/test_dereplicate_stage.py
+++ b/tests/test_dereplicate_stage.py
@@ -67,7 +67,7 @@ class TestDereplicateStage:
 
         expected_command = (
             f"usearch -fastx_uniques {expected_infile} "
-            f"-sizeout -relabel Uniq -threads 4 "
+            f"-sizeout -relabel Uniq -strand both -threads 4 "
             f"-fastaout {expected_outfile}"
         )
 

--- a/tests/test_lca_stage.py
+++ b/tests/test_lca_stage.py
@@ -1,0 +1,489 @@
+import os
+
+import pandas as pd
+import pytest
+
+from ednabp.bp.step_exec.lca import (
+    RANKS,
+    LcaStage,
+    filter_by_score,
+    lca_of_lineages,
+    normalize_species_names,
+)
+
+
+def blast_row(
+    qseqid,
+    bitscore,
+    kingdom="Eukaryota",
+    phylum="Chordata",
+    cls="Actinopteri",
+    order="Gadiformes",
+    family="Gadidae",
+    genus="Gadus",
+    species="Gadus_morhua",
+    pident=99.0,
+):
+    return {
+        "qseqid": qseqid,
+        "bitscore": bitscore,
+        "pident": pident,
+        "kingdom": kingdom,
+        "phylum": phylum,
+        "class": cls,
+        "order": order,
+        "family": family,
+        "genus": genus,
+        "species": species,
+    }
+
+
+class TestLcaStage:
+    @pytest.fixture
+    def lca_stage(self, mock_config, tmp_dirs):
+        in_dir, out_dir = tmp_dirs
+        return LcaStage(config=mock_config, in_dir=in_dir, out_dir=out_dir)
+
+    def test_normalize_simple_binomial(self):
+        assert normalize_species_names("Homo_sapiens") == ["Homo_sapiens"]
+
+    def test_normalize_subspecies_returns_full_then_base(self):
+        assert normalize_species_names("Homo_sapiens_neanderthalensis") == [
+            "Homo_sapiens_neanderthalensis",
+            "Homo_sapiens",
+        ]
+
+    def test_normalize_hybrid_splits_on_x(self):
+        assert normalize_species_names("Quercus_x_rosacea") == [
+            "Quercus",
+            "rosacea",
+        ]
+
+    def test_normalize_sp_notation(self):
+        assert "Gadus_sp." in normalize_species_names("Gadus_sp.-A12345")
+
+    def test_normalize_empty_string(self):
+        assert normalize_species_names("") == []
+
+    def test_filter_tol_zero_keeps_only_best(self):
+        g = pd.DataFrame({"bitscore": [300, 280, 250], "qseqid": ["q1"] * 3})
+        assert list(
+            filter_by_score(g, "bitscore", tol_pct=0.0)["bitscore"]
+        ) == [300]
+
+    def test_filter_tol_nonzero_keeps_within_window(self):
+        g = pd.DataFrame({"bitscore": [300, 295, 280], "qseqid": ["q1"] * 3})
+        assert set(
+            filter_by_score(g, "bitscore", tol_pct=2.0)["bitscore"]
+        ) == {
+            300,
+            295,
+        }
+
+    def test_filter_empty_group(self):
+        g = pd.DataFrame({"bitscore": [], "qseqid": []})
+        assert filter_by_score(g, "bitscore", tol_pct=0.0).empty
+
+    def test_filter_all_equal_scores_keeps_all(self):
+        g = pd.DataFrame({"bitscore": [200, 200, 200], "qseqid": ["q1"] * 3})
+        assert len(filter_by_score(g, "bitscore", tol_pct=0.0)) == 3
+
+    def test_lca_identical_lineages(self):
+        lineage = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "Gadiformes",
+            "Gadidae",
+            "Gadus",
+            "Gadus_morhua",
+        ]
+        lca, rank = lca_of_lineages([lineage, lineage])
+        assert rank == "species"
+        assert lca[RANKS.index("species")] == "Gadus_morhua"
+
+    def test_lca_diverge_at_species(self):
+        l1 = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "Gadiformes",
+            "Gadidae",
+            "Gadus",
+            "Gadus_morhua",
+        ]
+        l2 = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "Gadiformes",
+            "Gadidae",
+            "Gadus",
+            "Gadus_chalcogrammus",
+        ]
+        lca, rank = lca_of_lineages([l1, l2])
+        assert rank == "genus"
+        assert lca[RANKS.index("species")] == ""
+
+    def test_lca_diverge_at_genus(self):
+        l1 = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "Gadiformes",
+            "Gadidae",
+            "Gadus",
+            "Gadus_morhua",
+        ]
+        l2 = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "Gadiformes",
+            "Gadidae",
+            "Melanogrammus",
+            "Melanogrammus_aeglefinus",
+        ]
+        lca, rank = lca_of_lineages([l1, l2])
+        assert rank == "family"
+        assert lca[RANKS.index("genus")] == ""
+
+    def test_lca_diverge_at_kingdom(self):
+        l1 = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "Gadiformes",
+            "Gadidae",
+            "Gadus",
+            "Gadus_morhua",
+        ]
+        l2 = ["Bacteria", "Proteobacteria", "", "", "", "", ""]
+        lca, rank = lca_of_lineages([l1, l2])
+        assert rank == "NA"
+        assert all(v == "" for v in lca)
+
+    def test_lca_empty(self):
+        lca, rank = lca_of_lineages([])
+        assert rank == "NA"
+        assert lca == [""] * len(RANKS)
+
+    def test_lca_subspecies_with_species(self):
+        l1 = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "Gadiformes",
+            "Gadidae",
+            "Gadus",
+            "Gadus_morhua_callarias",
+        ]
+        l2 = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "Gadiformes",
+            "Gadidae",
+            "Gadus",
+            "Gadus_morhua",
+        ]
+        lca, rank = lca_of_lineages([l1, l2])
+        assert rank == "species"
+        assert lca[RANKS.index("species")] == "Gadus_morhua"
+
+    def test_lca_single_lineage(self):
+        lineage = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "Gadiformes",
+            "Gadidae",
+            "Gadus",
+            "Gadus_morhua",
+        ]
+        lca, rank = lca_of_lineages([lineage])
+        assert rank == "species"
+        assert lca == [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "Gadiformes",
+            "Gadidae",
+            "Gadus",
+            "Gadus_morhua",
+        ]
+
+    def test_lca_missing_middle_rank(self):
+        l1 = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "",
+            "Gadidae",
+            "Gadus",
+            "Gadus_morhua",
+        ]
+        l2 = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "",
+            "Gadidae",
+            "Gadus",
+            "Gadus_morhua",
+        ]
+        lca, rank = lca_of_lineages([l1, l2])
+        assert rank == "species"
+        assert lca[RANKS.index("order")] == ""
+        assert lca[RANKS.index("family")] == "Gadidae"
+        assert lca[RANKS.index("genus")] == "Gadus"
+        assert lca[RANKS.index("species")] == "Gadus_morhua"
+
+    def test_lca_intraspecific_assignment(self):
+        lineage = [
+            "Eukaryota",
+            "Chordata",
+            "Actinopteri",
+            "Gadiformes",
+            "Gadidae",
+            "Gadus",
+            "Gadus_morhua_callarias",
+        ]
+        lca, rank = lca_of_lineages([lineage, lineage])
+        assert rank == "species"
+        assert lca[RANKS.index("species")] == "Gadus_morhua_callarias"
+
+    def test_init(self, mock_config, tmp_dirs):
+        in_dir, out_dir = tmp_dirs
+        stage = LcaStage(config=mock_config, in_dir=in_dir, out_dir=out_dir)
+
+        assert stage.config == mock_config
+        assert stage.in_dir == in_dir
+        assert stage.out_dir == out_dir
+        assert stage.in_suffix == ".csv"
+        assert stage.out_suffix == ".csv"
+        assert stage.tol_pct == 1.0
+        assert stage.score_column == "bitscore"
+        assert stage.qseqid_column == "qseqid"
+        assert os.path.isdir(out_dir)
+
+    def test_init_custom(self, mock_config, tmp_dirs):
+        in_dir, out_dir = tmp_dirs
+        stage = LcaStage(
+            config=mock_config,
+            heading="custom_lca",
+            in_dir=in_dir,
+            out_dir=out_dir,
+            tol_pct=5.0,
+            score_column="evalue",
+            qseqid_column="query_id",
+        )
+
+        assert stage.heading == "custom_lca"
+        assert stage.tol_pct == 5.0
+        assert stage.score_column == "evalue"
+        assert stage.qseqid_column == "query_id"
+
+    def test_setup(self, lca_stage, tmp_dirs):
+        in_dir, out_dir = tmp_dirs
+        test_prefix = "sample001"
+        input_file = os.path.join(in_dir, f"{test_prefix}.csv")
+        pd.DataFrame([blast_row("Zotu1", 300)]).to_csv(input_file, index=False)
+
+        lca_stage.setup(test_prefix)
+
+        assert len(lca_stage.runners) == 1
+        assert lca_stage.infile == input_file
+        assert lca_stage.outfile == os.path.join(out_dir, f"{test_prefix}.csv")
+
+    def test_setup_missing_infile_raises(self, lca_stage):
+        with pytest.raises(FileNotFoundError):
+            lca_stage.setup("nonexistent")
+
+    def test_setup_dry_skips_runner(self, dry_config, tmp_dirs):
+        in_dir, out_dir = tmp_dirs
+        stage = LcaStage(config=dry_config, in_dir=in_dir, out_dir=out_dir)
+        input_file = os.path.join(in_dir, "sample001.csv")
+        pd.DataFrame([blast_row("Zotu1", 300)]).to_csv(input_file, index=False)
+
+        stage.setup("sample001")
+
+        assert len(stage.runners) == 0
+
+    def test_run_lca_single_hit_resolves_to_species(self, lca_stage, tmp_dirs):
+        in_dir, out_dir = tmp_dirs
+        lca_stage.infile = os.path.join(in_dir, "test.csv")
+        lca_stage.outfile = os.path.join(out_dir, "test.csv")
+        pd.DataFrame([blast_row("Zotu1", 300)]).to_csv(
+            lca_stage.infile, index=False
+        )
+
+        result = lca_stage.run_lca()
+
+        assert result is True
+        output = pd.read_csv(lca_stage.outfile)
+        assert (
+            output.loc[output["qseqid"] == "Zotu1", "lca_rank"].iloc[0]
+            == "species"
+        )
+
+    def test_run_lca_diverging_species_resolves_to_genus(
+        self, lca_stage, tmp_dirs
+    ):
+        in_dir, out_dir = tmp_dirs
+        lca_stage.infile = os.path.join(in_dir, "test.csv")
+        lca_stage.outfile = os.path.join(out_dir, "test.csv")
+        rows = [
+            blast_row("Zotu1", 300, species="Gadus_morhua"),
+            blast_row("Zotu1", 300, species="Gadus_chalcogrammus"),
+        ]
+        pd.DataFrame(rows).to_csv(lca_stage.infile, index=False)
+
+        lca_stage.run_lca()
+
+        output = pd.read_csv(lca_stage.outfile)
+        row = output.loc[output["qseqid"] == "Zotu1"].iloc[0]
+        assert row["lca_rank"] == "genus"
+        assert pd.isna(row["species"])
+
+    def test_run_lca_tight_tol_pct_excludes_low_score_hit(
+        self, lca_stage, tmp_dirs
+    ):
+        in_dir, out_dir = tmp_dirs
+        lca_stage.infile = os.path.join(in_dir, "test.csv")
+        lca_stage.outfile = os.path.join(out_dir, "test.csv")
+        rows = [
+            blast_row("Zotu1", 300, species="Gadus_morhua"),
+            blast_row("Zotu1", 300, species="Gadus_morhua"),
+            blast_row(
+                "Zotu1",
+                250,
+                genus="Melanogrammus",
+                species="Melanogrammus_aeglefinus",
+            ),
+        ]
+        pd.DataFrame(rows).to_csv(lca_stage.infile, index=False)
+
+        lca_stage.run_lca()
+
+        output = pd.read_csv(lca_stage.outfile)
+        assert (
+            output.loc[output["qseqid"] == "Zotu1", "lca_rank"].iloc[0]
+            == "species"
+        )
+
+    def test_run_lca_wide_tol_pct_causes_family_lca(
+        self, mock_config, tmp_dirs
+    ):
+        in_dir, out_dir = tmp_dirs
+        stage = LcaStage(
+            config=mock_config, in_dir=in_dir, out_dir=out_dir, tol_pct=2.0
+        )
+        stage.infile = os.path.join(in_dir, "test.csv")
+        stage.outfile = os.path.join(out_dir, "test.csv")
+        rows = [
+            blast_row("Zotu1", 300, species="Gadus_morhua"),
+            blast_row(
+                "Zotu1",
+                295,
+                genus="Melanogrammus",
+                species="Melanogrammus_aeglefinus",
+            ),
+        ]
+        pd.DataFrame(rows).to_csv(stage.infile, index=False)
+
+        stage.run_lca()
+
+        output = pd.read_csv(stage.outfile)
+        assert (
+            output.loc[output["qseqid"] == "Zotu1", "lca_rank"].iloc[0]
+            == "family"
+        )
+
+    def test_run_lca_multiple_queries(self, lca_stage, tmp_dirs):
+        in_dir, out_dir = tmp_dirs
+        lca_stage.infile = os.path.join(in_dir, "test.csv")
+        lca_stage.outfile = os.path.join(out_dir, "test.csv")
+        rows = [
+            blast_row("Zotu1", 300, species="Gadus_morhua"),
+            blast_row("Zotu2", 300, species="Gadus_chalcogrammus"),
+        ]
+        pd.DataFrame(rows).to_csv(lca_stage.infile, index=False)
+
+        lca_stage.run_lca()
+
+        output = pd.read_csv(lca_stage.outfile)
+        assert len(output) == 2
+        assert set(output["qseqid"]) == {"Zotu1", "Zotu2"}
+
+    def test_run_lca_num_assignments_counts_filtered_hits(
+        self, lca_stage, tmp_dirs
+    ):
+        in_dir, out_dir = tmp_dirs
+        lca_stage.infile = os.path.join(in_dir, "test.csv")
+        lca_stage.outfile = os.path.join(out_dir, "test.csv")
+        rows = [
+            blast_row("Zotu1", 300),
+            blast_row("Zotu1", 300),
+            blast_row("Zotu1", 100),
+        ]
+        pd.DataFrame(rows).to_csv(lca_stage.infile, index=False)
+
+        lca_stage.run_lca()
+
+        output = pd.read_csv(lca_stage.outfile)
+        assert (
+            output.loc[output["qseqid"] == "Zotu1", "num_assignments"].iloc[0]
+            == 2
+        )
+
+    def test_run_lca_best_row_metadata_from_highest_score(
+        self, mock_config, tmp_dirs
+    ):
+        in_dir, out_dir = tmp_dirs
+        stage = LcaStage(
+            config=mock_config, in_dir=in_dir, out_dir=out_dir, tol_pct=7.0
+        )
+        stage.infile = os.path.join(in_dir, "test.csv")
+        stage.outfile = os.path.join(out_dir, "test.csv")
+        rows = [
+            blast_row("Zotu1", 300, pident=99.0),
+            blast_row("Zotu1", 280, pident=85.0),
+        ]
+        pd.DataFrame(rows).to_csv(stage.infile, index=False)
+
+        stage.run_lca()
+
+        output = pd.read_csv(stage.outfile)
+        assert (
+            output.loc[output["qseqid"] == "Zotu1", "pident"].iloc[0] == 99.0
+        )
+
+    def test_run_lca_output_has_expected_columns(self, lca_stage, tmp_dirs):
+        in_dir, out_dir = tmp_dirs
+        lca_stage.infile = os.path.join(in_dir, "test.csv")
+        lca_stage.outfile = os.path.join(out_dir, "test.csv")
+        pd.DataFrame([blast_row("Zotu1", 300)]).to_csv(
+            lca_stage.infile, index=False
+        )
+
+        lca_stage.run_lca()
+
+        output = pd.read_csv(lca_stage.outfile)
+        assert "lca_rank" in output.columns
+        assert "num_assignments" in output.columns
+
+    def test_run_lca_returns_false_on_missing_taxonomy_columns(
+        self, lca_stage, tmp_dirs
+    ):
+        in_dir, out_dir = tmp_dirs
+        lca_stage.infile = os.path.join(in_dir, "test.csv")
+        lca_stage.outfile = os.path.join(out_dir, "test.csv")
+        pd.DataFrame({"qseqid": ["Zotu1"], "bitscore": [300]}).to_csv(
+            lca_stage.infile, index=False
+        )
+
+        result = lca_stage.run_lca()
+
+        assert result is False
+        lca_stage.config.logger.error.assert_called()


### PR DESCRIPTION
1. Implement lowest common ancestor (LCA) in the bp module
- Find the intersection for the set of candidate top hits from broadest to finest ranks. LCA=Finest non-empty intersection
- Update maxhitnum default value: 1 -> 20

2. Update arguments
- Add denoise_dir for the addhap stage
- Add arguments revcomp, strand in cutprimer, dereplicate stages to consider reverse-complement patterns